### PR TITLE
엔티티 설계

### DIFF
--- a/src/main/java/com/server/amething/domain/DomainClass.java
+++ b/src/main/java/com/server/amething/domain/DomainClass.java
@@ -1,4 +1,0 @@
-package com.server.amething.domain;
-
-public class DomainClass {
-}

--- a/src/main/java/com/server/amething/domain/answer/Answer.java
+++ b/src/main/java/com/server/amething/domain/answer/Answer.java
@@ -1,0 +1,25 @@
+package com.server.amething.domain.answer;
+
+import com.server.amething.domain.question.Question;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity @Table(name = "answer")
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Answer {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "answer_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Column(name = "answer_description")
+    private String description;
+}
+

--- a/src/main/java/com/server/amething/domain/answer/Answer.java
+++ b/src/main/java/com/server/amething/domain/answer/Answer.java
@@ -21,5 +21,6 @@ public class Answer {
 
     @Column(name = "answer_description")
     private String description;
+
 }
 

--- a/src/main/java/com/server/amething/domain/member/Member.java
+++ b/src/main/java/com/server/amething/domain/member/Member.java
@@ -1,0 +1,4 @@
+package com.server.amething.domain.member;
+
+public class Member {
+}

--- a/src/main/java/com/server/amething/domain/member/Member.java
+++ b/src/main/java/com/server/amething/domain/member/Member.java
@@ -1,7 +1,6 @@
 package com.server.amething.domain.member;
 
 import lombok.*;
-import org.hibernate.annotations.Cascade;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/server/amething/domain/member/Member.java
+++ b/src/main/java/com/server/amething/domain/member/Member.java
@@ -1,4 +1,34 @@
 package com.server.amething.domain.member;
 
+import lombok.*;
+import org.hibernate.annotations.Cascade;
+
+import javax.persistence.*;
+
+@Entity @Table(name = "member")
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "member_nickname")
+    private String nickname;
+
+    @Column(name = "member_password")
+    private String password;
+
+    @Column(name = "member_name")
+    private String memberName;
+
+    @Column(name = "member_bio")
+    private String bio;
+
+    @Column(name = "member_profile_picture")
+    private String profilePicture;
+
 }
+

--- a/src/main/java/com/server/amething/domain/question/Question.java
+++ b/src/main/java/com/server/amething/domain/question/Question.java
@@ -1,2 +1,34 @@
-package com.server.amething.domain.question;public class Question {
+package com.server.amething.domain.question;
+
+import com.server.amething.domain.member.Member;
+import com.server.amething.domain.question.enum_type.QuestionType;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity @Table(name = "question")
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Question {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "receiver_member_id")
+    private Member receiverMember;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "sent_member_id")
+    private Member sentMember;
+
+    @Column(name = "question_description")
+    private String description;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "question_type")
+    private QuestionType type;
+
 }

--- a/src/main/java/com/server/amething/domain/question/Question.java
+++ b/src/main/java/com/server/amething/domain/question/Question.java
@@ -17,12 +17,12 @@ public class Question {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "receiver_member_id")
-    private Member receiverMember;
+    @JoinColumn(name = "owner_member_id")
+    private Member ownerMember;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "sender_member_id")
-    private Member senderMember;
+    @JoinColumn(name = "visitor_member_id")
+    private Member visitorMember;
 
     @Column(name = "question_description")
     private String description;

--- a/src/main/java/com/server/amething/domain/question/Question.java
+++ b/src/main/java/com/server/amething/domain/question/Question.java
@@ -21,8 +21,8 @@ public class Question {
     private Member receiverMember;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "sent_member_id")
-    private Member sentMember;
+    @JoinColumn(name = "sender_member_id")
+    private Member senderMember;
 
     @Column(name = "question_description")
     private String description;

--- a/src/main/java/com/server/amething/domain/question/Question.java
+++ b/src/main/java/com/server/amething/domain/question/Question.java
@@ -17,8 +17,8 @@ public class Question {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "owner_member_id")
-    private Member ownerMember;
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Column(name = "question_description")
     private String description;

--- a/src/main/java/com/server/amething/domain/question/Question.java
+++ b/src/main/java/com/server/amething/domain/question/Question.java
@@ -20,10 +20,6 @@ public class Question {
     @JoinColumn(name = "owner_member_id")
     private Member ownerMember;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "visitor_member_id")
-    private Member visitorMember;
-
     @Column(name = "question_description")
     private String description;
 

--- a/src/main/java/com/server/amething/domain/question/Question.java
+++ b/src/main/java/com/server/amething/domain/question/Question.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.question;public class Question {
+}

--- a/src/main/java/com/server/amething/domain/question/enum_type/QuestionType.java
+++ b/src/main/java/com/server/amething/domain/question/enum_type/QuestionType.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.question.enum_type;public class Question t{
+}

--- a/src/main/java/com/server/amething/domain/question/enum_type/QuestionType.java
+++ b/src/main/java/com/server/amething/domain/question/enum_type/QuestionType.java
@@ -1,2 +1,10 @@
-package com.server.amething.domain.question.enum_type;public class Question t{
+package com.server.amething.domain.question.enum_type;
+
+/**
+ * PIN: 고정된 질문
+ * BASIC: 일반 질문
+ * UNCOMMENT: 답변하지 않은 질문
+ */
+public enum QuestionType {
+    PIN, BASIC, UNCOMMENT
 }

--- a/src/main/java/com/server/amething/domain/question/enum_type/QuestionType.java
+++ b/src/main/java/com/server/amething/domain/question/enum_type/QuestionType.java
@@ -2,9 +2,8 @@ package com.server.amething.domain.question.enum_type;
 
 /**
  * PIN: 고정된 질문
- * BASIC: 일반 질문
- * UNCOMMENT: 답변하지 않은 질문
+ * UNREPLY: 답변하지 않은 질문
  */
 public enum QuestionType {
-    PIN, BASIC, UNCOMMENT
+    PIN, UNREPLY
 }


### PR DESCRIPTION
질문을 관리하는 테이블, 멤버 테이블, 답변 테이블을 설계했어요.

우선 질문 테이블의 멤버 외래키 2개는 각각 질문을 하는 멤버의 기본키, 질문을 받는 멤버의 기본키로 두어서
자기가 한 질문 List와 받은 질문 List를 동시에 확인 할 수 있게 설계하였습니다.

QuestionType의 enum은 주석으로 각각 역할 명시하였습니다.

기능 명세서와 Oauth2의 reference를 참고하여 멤버 테이블을 설계 하였지만 추후에 변동이 있을 수 있다는점 알아주세요!