### PR TITLE
Kakao Oauth를 이용한 회원 정보 추출및 저장 로직 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// *** OAuth2 ***
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// *** Querydsl ***
 	implementation 'com.querydsl:querydsl-jpa'
 
@@ -45,8 +48,10 @@ dependencies {
 	// *** Swagger UI ***
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
-}
 
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
+	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5'
+}
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/src/main/java/com/server/amething/domain/auth/config/OauthConfig.java
+++ b/src/main/java/com/server/amething/domain/auth/config/OauthConfig.java
@@ -1,0 +1,19 @@
+package com.server.amething.domain.auth.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class OauthConfig {
+
+    @Value("${client-id}")
+    private String clientId;
+
+    @Value("${redirect-uri}")
+    private String redirectUri;
+
+    @Value("${client-secret}")
+    private String clientSecret;
+}

--- a/src/main/java/com/server/amething/domain/auth/controller/OauthController.java
+++ b/src/main/java/com/server/amething/domain/auth/controller/OauthController.java
@@ -1,65 +1,28 @@
 package com.server.amething.domain.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.amething.domain.auth.config.AuthConfig;
 import com.server.amething.domain.auth.dto.OauthResponseDto;
+import com.server.amething.domain.auth.dto.UserProfileResponseDto;
+import com.server.amething.domain.auth.service.OauthService;
+import com.server.amething.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
 @RestController
-@RequestMapping("/v1")
+@RequestMapping("/oauth")
 @RequiredArgsConstructor
-public class AuthController {
+public class OauthController {
 
-    private final AuthConfig oauthConfig;
-    private final ObjectMapper objectMapper;
+    private final OauthService oauthService;
+    private final UserService userService;
 
-    @GetMapping("auth/code")
-    private OauthResponseDto getAuthorizationCode(@RequestParam String code) throws JsonProcessingException {
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("grant_type", "authorization_code");
-        parameters.add("client_id", oauthConfig.getClientId());
-        parameters.add("redirect_uri", oauthConfig.getRedirectUri());
-        parameters.add("code", code);
-        parameters.add("client_secret", oauthConfig.getClientSecret());
-
-        HttpEntity<MultiValueMap<String, String>> httpRequest = new HttpEntity<>(parameters, headers);
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                "https://kauth.kakao.com/oauth/token",
-                HttpMethod.POST,
-                httpRequest,
-                String.class
-        );
-
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        OauthResponseDto oauthResponseDto = null;
-
-        try {
-            oauthResponseDto = objectMapper.readValue(response.getBody(), OauthResponseDto.class);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-
-        return oauthResponseDto;
+    @GetMapping("/code")
+    private void getAuthorizationCode(@RequestParam String code) throws JsonProcessingException {
+        OauthResponseDto token = oauthService.getAccessToken(code);
+        UserProfileResponseDto userProfile = oauthService.getUserProfile(token.getAccess_token());
+        userService.saveUserInfo(userProfile);
     }
 }

--- a/src/main/java/com/server/amething/domain/auth/controller/OauthController.java
+++ b/src/main/java/com/server/amething/domain/auth/controller/OauthController.java
@@ -1,7 +1,7 @@
 package com.server.amething.domain.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.server.amething.domain.auth.dto.OauthResponseDto;
+import com.server.amething.domain.auth.dto.TokenResponseDto;
 import com.server.amething.domain.auth.dto.UserProfileResponseDto;
 import com.server.amething.domain.auth.service.OauthService;
 import com.server.amething.domain.user.service.UserService;
@@ -21,7 +21,7 @@ public class OauthController {
 
     @GetMapping("/code")
     private void getAuthorizationCode(@RequestParam String code) throws JsonProcessingException {
-        OauthResponseDto token = oauthService.getAccessToken(code);
+        TokenResponseDto token = oauthService.getAccessToken(code);
         UserProfileResponseDto userProfile = oauthService.getUserProfile(token.getAccess_token());
         userService.saveUserInfo(userProfile);
     }

--- a/src/main/java/com/server/amething/domain/auth/controller/OauthController.java
+++ b/src/main/java/com/server/amething/domain/auth/controller/OauthController.java
@@ -1,0 +1,65 @@
+package com.server.amething.domain.auth.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.amething.domain.auth.config.AuthConfig;
+import com.server.amething.domain.auth.dto.OauthResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthConfig oauthConfig;
+    private final ObjectMapper objectMapper;
+
+    @GetMapping("auth/code")
+    private OauthResponseDto getAuthorizationCode(@RequestParam String code) throws JsonProcessingException {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("grant_type", "authorization_code");
+        parameters.add("client_id", oauthConfig.getClientId());
+        parameters.add("redirect_uri", oauthConfig.getRedirectUri());
+        parameters.add("code", code);
+        parameters.add("client_secret", oauthConfig.getClientSecret());
+
+        HttpEntity<MultiValueMap<String, String>> httpRequest = new HttpEntity<>(parameters, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                httpRequest,
+                String.class
+        );
+
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        OauthResponseDto oauthResponseDto = null;
+
+        try {
+            oauthResponseDto = objectMapper.readValue(response.getBody(), OauthResponseDto.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return oauthResponseDto;
+    }
+}

--- a/src/main/java/com/server/amething/domain/auth/dto/OauthResponseDto.java
+++ b/src/main/java/com/server/amething/domain/auth/dto/OauthResponseDto.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.auth.dto;public class OauthResponseDto {
+}

--- a/src/main/java/com/server/amething/domain/auth/dto/OauthResponseDto.java
+++ b/src/main/java/com/server/amething/domain/auth/dto/OauthResponseDto.java
@@ -1,2 +1,0 @@
-package com.server.amething.domain.auth.dto;public class OauthResponseDto {
-}

--- a/src/main/java/com/server/amething/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/server/amething/domain/auth/dto/TokenResponseDto.java
@@ -1,0 +1,17 @@
+package com.server.amething.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponseDto {
+    private String token_type;
+    private String access_token;
+    private Integer expires_in;
+    private String refresh_token;
+    private Integer refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/com/server/amething/domain/auth/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/server/amething/domain/auth/dto/UserProfileResponseDto.java
@@ -1,2 +1,47 @@
-package com.server.amething.domain.auth.dto;public class UserProfileResponseDto {
+package com.server.amething.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponseDto {
+    private long id;
+    private String connected_at;
+    private Properties properties;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public class Properties {
+        private String nickname;
+        private String profile_image;
+        private String thumbnail_image;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public class KakaoAcount {
+        public Boolean profile_needs_agreement;
+        public Profile profile;
+        public Boolean has_email;
+        public Boolean email_needs_agreement;
+        public Boolean is_email_valid;
+        public Boolean is_email_verified;
+        public String email;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public class Profile {
+            public String nickname;
+            public String thumbnail_image_url;
+            public String profile_image_url;
+            public boolean is_default_image;
+        }
+    }
+
 }

--- a/src/main/java/com/server/amething/domain/auth/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/server/amething/domain/auth/dto/UserProfileResponseDto.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.auth.dto;public class UserProfileResponseDto {
+}

--- a/src/main/java/com/server/amething/domain/auth/service/OauthService.java
+++ b/src/main/java/com/server/amething/domain/auth/service/OauthService.java
@@ -1,2 +1,10 @@
-package com.server.amething.domain.auth.service;public class OauthService {
+package com.server.amething.domain.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.server.amething.domain.auth.dto.TokenResponseDto;
+import com.server.amething.domain.auth.dto.UserProfileResponseDto;
+
+public interface OauthService {
+    TokenResponseDto getAccessToken(String code) throws JsonProcessingException;
+    UserProfileResponseDto getUserProfile(String accessToken);
 }

--- a/src/main/java/com/server/amething/domain/auth/service/OauthService.java
+++ b/src/main/java/com/server/amething/domain/auth/service/OauthService.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.auth.service;public class OauthService {
+}

--- a/src/main/java/com/server/amething/domain/auth/service/OauthServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/auth/service/OauthServiceImpl.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.auth.service;public class OauthServiceImpl {
+}

--- a/src/main/java/com/server/amething/domain/auth/service/OauthServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/auth/service/OauthServiceImpl.java
@@ -1,2 +1,92 @@
-package com.server.amething.domain.auth.service;public class OauthServiceImpl {
+package com.server.amething.domain.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.amething.domain.auth.config.OauthConfig;
+import com.server.amething.domain.auth.dto.TokenResponseDto;
+import com.server.amething.domain.auth.dto.UserProfileResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OauthServiceImpl implements OauthService{
+
+    private final OauthConfig oauthConfig;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public TokenResponseDto getAccessToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("grant_type", "authorization_code");
+        parameters.add("client_id", oauthConfig.getClientId());
+        parameters.add("redirect_uri", oauthConfig.getRedirectUri());
+        parameters.add("code", code);
+        parameters.add("client_secret", oauthConfig.getClientSecret());
+
+        HttpEntity<MultiValueMap<String, String>> httpRequest = new HttpEntity<>(parameters, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                httpRequest,
+                String.class
+        );
+
+        TokenResponseDto oauthResponseDto = new TokenResponseDto();
+
+        try {
+            oauthResponseDto = objectMapper.readValue(response.getBody(), TokenResponseDto.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return oauthResponseDto;
+    }
+
+    @Override
+    public UserProfileResponseDto getUserProfile(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<HttpHeaders> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                request,
+                String.class
+        );
+
+        UserProfileResponseDto userProfileResponseDto = new UserProfileResponseDto();
+
+        try {
+            userProfileResponseDto = objectMapper.readValue(response.getBody(), UserProfileResponseDto.class);
+        } catch (JsonMappingException e) {
+            e.printStackTrace();
+        } catch (JsonProcessingException exception) {
+            exception.printStackTrace();
+        }
+
+        return userProfileResponseDto;
+    }
 }

--- a/src/main/java/com/server/amething/domain/user/User.java
+++ b/src/main/java/com/server/amething/domain/user/User.java
@@ -14,20 +14,10 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "user_nickname")
-    private String nickname;
-
-    @Column(name = "user_password")
-    private String password;
-
     @Column(name = "user_name")
-    private String memberName;
-
-    @Column(name = "user_bio")
-    private String bio;
+    private String userName;
 
     @Column(name = "user_profile_picture")
     private String profilePicture;
 
 }
-

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepository.java
@@ -1,2 +1,7 @@
-package com.server.amething.domain.user.repository;public class UserRepository {
+package com.server.amething.domain.user.repository;
+
+import com.server.amething.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
 }

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepository.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.user.repository;public class UserRepository {
+}

--- a/src/main/java/com/server/amething/domain/user/service/UserService.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserService.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.user.service;public interface UserService {
+}

--- a/src/main/java/com/server/amething/domain/user/service/UserService.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserService.java
@@ -1,2 +1,7 @@
-package com.server.amething.domain.user.service;public interface UserService {
+package com.server.amething.domain.user.service;
+
+import com.server.amething.domain.auth.dto.UserProfileResponseDto;
+
+public interface UserService {
+    void saveUserInfo(UserProfileResponseDto userProfileResponseDto);
 }

--- a/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
@@ -1,2 +1,23 @@
-package com.server.amething.domain.user.service;public class UserServiceImpl {
+package com.server.amething.domain.user.service;
+
+import com.server.amething.domain.auth.dto.UserProfileResponseDto;
+import com.server.amething.domain.user.User;
+import com.server.amething.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void saveUserInfo(UserProfileResponseDto userProfileResponseDto) {
+        userRepository.save(User.builder()
+                .userName(userProfileResponseDto.getProperties().getNickname())
+                .profilePicture(userProfileResponseDto.getProperties().getProfile_image())
+                .build()
+        );
+    }
 }

--- a/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.user.service;public class UserServiceImpl {
+}

--- a/src/main/java/com/server/amething/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/server/amething/global/config/security/WebSecurityConfig.java
@@ -23,7 +23,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
         http.authorizeRequests()
                 .antMatchers("/**").permitAll()
-                .anyRequest().authenticated();
+                .anyRequest().permitAll();
     }
 
     @Override


### PR DESCRIPTION
Kakao Oauth로 소셜 로그인 서비스 방식을 바꿨습니다.
기존 Facebook Oauth의 경우 reference도 많이 없고 무엇보다도 원래 사용하려 했던 instagram 메타데이터들을 개인계정이 아닌 프로페셔널 계정만 가져올 수 있어서 입니다.

지금 현재 Token 정보들을 받아오고 해당 Token을 기반으로 회원 메타 데이터를 가져오는 로직과
해당 데이터들을 User 엔티티에 저장하는 로직이 완성되었습니다.

현재 문제점은 같은 메타 데이터를 가진 회원이더라도 로그인 할때마다 row가 새롭게 생성됩니다.

<img width="814" alt="스크린샷 2022-05-21 16 52 18" src="https://user-images.githubusercontent.com/69895452/169641832-46f124c4-5b2c-4336-a18a-6ed6c5d34967.png">

현재 로그아웃 기능은 없지만 로그인만 3번 반복했을때 db 상황입니다.

첫 로그인시 컬럼 2개가 동시에 저장되는데 해당 이유는 원인 파악중에 있으며
마지막 row같은 경우 제 카카오톡 이름을 변경한뒤 새롭게 로그인 했을때의 데이터들인데

바로 동기화가 되는거 같습니다.

로그인시마다 row가 쌓이는 문제는 로그아웃했을때 deleteUserByUserId(currentMember.getId()) 이런식으로 로그아웃 할때마다 row를 삭제하는 방법도 고안중입니다. Oauth를 이용한 기능을 다 완성하고 pr을 보낼려했는데 그럴경우 Files Change도 굉장히 많아져서 코드리뷰에 용이하지 못할거 같아 해당 기능만 올리는점 죄송합니다!

코드리뷰 부탁드립니다

User 엔티티의 변동도 일어났기 때문에 확인 부탁드려요!