### PR TITLE
Feature/user profile fix

### DIFF
--- a/src/main/java/com/server/amething/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/amething/domain/user/controller/UserController.java
@@ -19,8 +19,8 @@ public class UserController {
     private final ResponseService responseService;
 
     @GetMapping("/user/{nickname}")
-    public SingleResult<ProfileDto> loadProfile(@PathVariable String nickname){
-        ProfileDto profileDto = userService.loadProfile(nickname);
+    public SingleResult<ProfileDto> loadProfile(@PathVariable Long oauthId){
+        ProfileDto profileDto = userService.loadProfile(oauthId);
         return responseService.getSingleResult(profileDto);
     }
 }

--- a/src/main/java/com/server/amething/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/amething/domain/user/controller/UserController.java
@@ -18,7 +18,7 @@ public class UserController {
     private final UserService userService;
     private final ResponseService responseService;
 
-    @GetMapping("/user/{nickname}")
+    @GetMapping("/user/{oauthId}")
     public SingleResult<ProfileDto> loadProfile(@PathVariable Long oauthId){
         ProfileDto profileDto = userService.loadProfile(oauthId);
         return responseService.getSingleResult(profileDto);

--- a/src/main/java/com/server/amething/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/amething/domain/user/controller/UserController.java
@@ -4,6 +4,8 @@ import com.server.amething.domain.user.dto.ProfileDto;
 import com.server.amething.domain.user.service.UserService;
 import com.server.amething.global.response.ResponseService;
 import com.server.amething.global.response.result.SingleResult;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +19,10 @@ public class UserController {
     private final ResponseService responseService;
 
     @ResponseStatus(HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "oauthId", value = "oauth 로그인시 기본 지급되는 Id", required = true, dataType = "Long", paramType = "path")
+    })
     @GetMapping("/user/{oauthId}")
     public SingleResult<ProfileDto> loadProfile(@PathVariable Long oauthId){
         ProfileDto profileDto = userService.loadProfile(oauthId);

--- a/src/main/java/com/server/amething/domain/user/controller/UserController.java
+++ b/src/main/java/com/server/amething/domain/user/controller/UserController.java
@@ -5,10 +5,8 @@ import com.server.amething.domain.user.service.UserService;
 import com.server.amething.global.response.ResponseService;
 import com.server.amething.global.response.result.SingleResult;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1")
@@ -18,6 +16,7 @@ public class UserController {
     private final UserService userService;
     private final ResponseService responseService;
 
+    @ResponseStatus(HttpStatus.OK )
     @GetMapping("/user/{oauthId}")
     public SingleResult<ProfileDto> loadProfile(@PathVariable Long oauthId){
         ProfileDto profileDto = userService.loadProfile(oauthId);

--- a/src/main/java/com/server/amething/domain/user/dto/ProfileDto.java
+++ b/src/main/java/com/server/amething/domain/user/dto/ProfileDto.java
@@ -11,4 +11,6 @@ public class ProfileDto {
     private String userName;
 
     private String profilePicture;
+
+    private String bio;
 }

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepositoryCustom.java
@@ -2,6 +2,8 @@ package com.server.amething.domain.user.repository;
 
 import com.server.amething.domain.user.dto.ProfileDto;
 
+import java.util.Optional;
+
 public interface UserRepositoryCustom {
-    ProfileDto findProfileByOauthId(Long oauthId);
+    Optional<ProfileDto> findProfileByOauthId(Long oauthId);
 }

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepositoryCustom.java
@@ -3,5 +3,5 @@ package com.server.amething.domain.user.repository;
 import com.server.amething.domain.user.dto.ProfileDto;
 
 public interface UserRepositoryCustom {
-    ProfileDto findProfileByNickname(String nickname);
+    ProfileDto findProfileByOauthId(Long oauthId);
 }

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.server.amething.domain.user.dto.ProfileDto;
 import lombok.RequiredArgsConstructor;
+import java.util.Optional;
 
 import static com.server.amething.domain.user.QUser.user;
 
@@ -14,12 +15,13 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
 
     @Override
     public ProfileDto findProfileByOauthId(Long oauthId) {
-        return queryFactory.from(user)
+    public Optional<ProfileDto> findProfileByOauthId(Long oauthId) {
+        return Optional.ofNullable(queryFactory.from(user)
                 .select(Projections.constructor(ProfileDto.class,
                         user.nickname,
-                        user.profilePicture
+                        user.profilePicture,
                         ))
                 .where(user.oauthId.eq(oauthId))
-                .fetchOne();
+                .fetchOne());
     }
 }

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.server.amething.domain.user.dto.ProfileDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Optional;
 
 import static com.server.amething.domain.user.QUser.user;
@@ -14,12 +16,13 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public ProfileDto findProfileByOauthId(Long oauthId) {
+    @Transactional(readOnly = true)
     public Optional<ProfileDto> findProfileByOauthId(Long oauthId) {
         return Optional.ofNullable(queryFactory.from(user)
                 .select(Projections.constructor(ProfileDto.class,
                         user.nickname,
                         user.profilePicture,
+                        user.bio
                         ))
                 .where(user.oauthId.eq(oauthId))
                 .fetchOne());

--- a/src/main/java/com/server/amething/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/server/amething/domain/user/repository/UserRepositoryImpl.java
@@ -13,13 +13,13 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public ProfileDto findProfileByNickname(String nickname) {
+    public ProfileDto findProfileByOauthId(Long oauthId) {
         return queryFactory.from(user)
                 .select(Projections.constructor(ProfileDto.class,
                         user.nickname,
                         user.profilePicture
                         ))
-                .where(user.nickname.eq(nickname))
+                .where(user.oauthId.eq(oauthId))
                 .fetchOne();
     }
 }

--- a/src/main/java/com/server/amething/domain/user/service/UserService.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserService.java
@@ -9,5 +9,5 @@ import java.util.Map;
 
 public interface UserService {
     Map<String, String> login(UserProfileResponseDto userProfileResponseDto, List<Role> roles);
-    ProfileDto loadProfile(String nickname);
+    ProfileDto loadProfile(Long oauthId);
 }

--- a/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
@@ -90,8 +90,8 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public ProfileDto loadProfile(String nickname) {
-        ProfileDto profileDto = userRepository.findProfileByNickname(nickname);
+    public ProfileDto loadProfile(Long oauthId) {
+        ProfileDto profileDto = userRepository.findProfileByOauthId(oauthId);
         return profileDto;
     }
 }

--- a/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/user/service/UserServiceImpl.java
@@ -89,9 +89,18 @@ public class UserServiceImpl implements UserService{
         user.changeNickname(userProfileResponseDto.getProperties().getNickname());
     }
 
+    /**
+     * User의 프로필 정보를 가져오는 메소드.
+     * PathVariable 어노테이션을 통해 URL에서 고유한 oauthId를 가져온 후에
+     * 해당 oauthId을 기반으로 해당 유저의 프로필 정보를 조회한다.
+     * 그리고 조회한 유저의 프로필 정보를 return 한다.
+     * @param oauthId User들의 고유한 ID
+     * @return profileDto - 조회한 유저의 프로필 정보
+     * @author 정용우
+    */
     @Override
     public ProfileDto loadProfile(Long oauthId) {
-        ProfileDto profileDto = userRepository.findProfileByOauthId(oauthId);
-        return profileDto;
+        return userRepository.findProfileByOauthId(oauthId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디로 만들어진 프로필이 존재하지 않습니다."));
     }
 }

--- a/src/test/java/com/server/amething/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/server/amething/domain/user/controller/UserControllerTest.java
@@ -41,11 +41,12 @@ class UserControllerTest {
     void loadProfile() throws Exception {
         //given
         Long id = 1234567891L;
-        ProfileDto profileDto = new ProfileDto("user","img");
+        ProfileDto profileDto = new ProfileDto("user","img","Hello!!");
         userRepository.save(User.builder()
                 .oauthId(id)
                 .nickname(profileDto.getUserName())
                 .profilePicture(profileDto.getProfilePicture())
+                .bio(profileDto.getBio())
                 .build());
         //when
         final ResultActions resultActions = mvc.perform(get("/v1/user/{id}", id)

--- a/src/test/java/com/server/amething/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/server/amething/domain/user/controller/UserControllerTest.java
@@ -40,13 +40,15 @@ class UserControllerTest {
     @DisplayName("프로필 구현을 위한 정보를 가져오는 컨트롤러")
     void loadProfile() throws Exception {
         //given
+        Long id = 1234567891L;
         ProfileDto profileDto = new ProfileDto("user","img");
         userRepository.save(User.builder()
+                .oauthId(id)
                 .nickname(profileDto.getUserName())
                 .profilePicture(profileDto.getProfilePicture())
                 .build());
         //when
-        final ResultActions resultActions = mvc.perform(get("/v1/user/{forumName}", profileDto.getUserName())
+        final ResultActions resultActions = mvc.perform(get("/v1/user/{id}", id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("UTF-8"));
         //then

--- a/src/test/java/com/server/amething/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/amething/domain/user/service/UserServiceTest.java
@@ -23,11 +23,12 @@ class UserServiceTest {
     void loadProfile() {
         //given
         Long id = 1234567891L;
-        ProfileDto profileDto = new ProfileDto("user","img");
+        ProfileDto profileDto = new ProfileDto("user","img","안녕하세요 user입니다.");
         userRepository.save(User.builder()
                         .oauthId(id)
                         .nickname(profileDto.getUserName())
                         .profilePicture(profileDto.getProfilePicture())
+                        .bio(profileDto.getBio())
                         .build());
         //when
         ProfileDto user = userService.loadProfile(id);

--- a/src/test/java/com/server/amething/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/server/amething/domain/user/service/UserServiceTest.java
@@ -22,13 +22,15 @@ class UserServiceTest {
     @DisplayName("프로필 구현을 위한 정보를 가져오는 로직")
     void loadProfile() {
         //given
+        Long id = 1234567891L;
         ProfileDto profileDto = new ProfileDto("user","img");
         userRepository.save(User.builder()
+                        .oauthId(id)
                         .nickname(profileDto.getUserName())
                         .profilePicture(profileDto.getProfilePicture())
                         .build());
         //when
-        ProfileDto user = userService.loadProfile(profileDto.getUserName());
+        ProfileDto user = userService.loadProfile(id);
 
         //then
         assertThat(user.getUserName()).isEqualTo(profileDto.getUserName());


### PR DESCRIPTION
#12 PR에서 받은 코멘트들을 적용시켰습니다!
- 유저의 프로필 정보를 가져올 때 bio (자기소개) 컬럼을 추가로 가져올 수 있도록 로직을 변경하였습니다!
> 저번 버전에서는 User Entity에 bio 컬럼이 없어 추가하지 못했었습니다..
- findProfileByUsername 메소드가 읽기 전용 쿼리이기에 `@Transactional(readOnly = true)`을 추가했어요!
- 또한 메소드 책임상 충분히 Null값을 반환할 수 있기에 Optional로 값을 감싸 Null-Safe 한 객체(Optional)로 리턴하게 변경했습니다!