### PR TITLE
RefreshToken을 이용한 AccessToken 재발급

### DIFF
--- a/src/main/java/com/server/amething/domain/token/controller/TokenController.java
+++ b/src/main/java/com/server/amething/domain/token/controller/TokenController.java
@@ -1,2 +1,32 @@
-package com.server.amething.domain.token.controller;public class TokenController {
+package com.server.amething.domain.token.controller;
+
+import com.server.amething.domain.token.service.TokenService;
+import com.server.amething.global.response.ResponseService;
+import com.server.amething.global.response.result.SingleResult;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final TokenService tokenService;
+    private final ResponseService responseService;
+
+    @GetMapping("/reissue/access-token")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "RefreshToken", value = "refreshToken", required = true, dataType = "String", paramType = "header"),
+    })
+    private SingleResult<String> reissueAccessToken(HttpServletRequest request, @RequestParam Long oauthId) {
+
+        return responseService.getSingleResult(tokenService.reissueAccessToken(request, oauthId));
+    }
+
 }

--- a/src/main/java/com/server/amething/domain/token/controller/TokenController.java
+++ b/src/main/java/com/server/amething/domain/token/controller/TokenController.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.token.controller;public class TokenController {
+}

--- a/src/main/java/com/server/amething/domain/token/service/TokenService.java
+++ b/src/main/java/com/server/amething/domain/token/service/TokenService.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.token.service;public interface TokenService {
+}

--- a/src/main/java/com/server/amething/domain/token/service/TokenService.java
+++ b/src/main/java/com/server/amething/domain/token/service/TokenService.java
@@ -1,2 +1,8 @@
-package com.server.amething.domain.token.service;public interface TokenService {
+package com.server.amething.domain.token.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface TokenService {
+
+    String reissueAccessToken(HttpServletRequest request, Long oauthId);
 }

--- a/src/main/java/com/server/amething/domain/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/token/service/TokenServiceImpl.java
@@ -1,0 +1,2 @@
+package com.server.amething.domain.token.service;public class TokenServiceImpl {
+}

--- a/src/main/java/com/server/amething/domain/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/server/amething/domain/token/service/TokenServiceImpl.java
@@ -1,2 +1,33 @@
-package com.server.amething.domain.token.service;public class TokenServiceImpl {
+package com.server.amething.domain.token.service;
+
+import com.server.amething.domain.user.User;
+import com.server.amething.domain.user.repository.UserRepository;
+import com.server.amething.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+@RequiredArgsConstructor
+public class TokenServiceImpl implements TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public String reissueAccessToken(HttpServletRequest request, Long oauthId) {
+        String requestRefreshToken = jwtTokenProvider.resolveRefreshToken(request);
+
+        User user = userRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        String userRefreshToken = user.getRefreshToken().substring(7);
+
+        if (userRefreshToken.equals(requestRefreshToken)) {
+            String accessToken = jwtTokenProvider.createAccessToken(user.getUsername(), user.getRoles());
+            return accessToken;
+        } else throw new IllegalArgumentException("refreshToken이 없거나 유효하지 않습니다.");
+
+    }
 }

--- a/src/main/java/com/server/amething/domain/user/User.java
+++ b/src/main/java/com/server/amething/domain/user/User.java
@@ -95,4 +95,8 @@ public class User implements UserDetails {
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void changeRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/server/amething/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/server/amething/global/config/security/WebSecurityConfig.java
@@ -1,6 +1,15 @@
 package com.server.amething.global.config.security;
 
+import com.server.amething.global.jwt.JwtTokenProvider;
+import com.server.amething.global.jwt.config.JwtFilterConfig;
+import com.server.amething.global.jwt.exception.ExceptionHandlerFilter;
+//import com.server.amething.global.jwt.exception.ExceptionHandlerFilterConfig;
+import com.server.amething.global.jwt.exception.ExceptionHandlerFilterConfig;
+import com.server.amething.global.jwt.exception.JwtAccessDeniedHandler;
+import com.server.amething.global.jwt.exception.JwtAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -9,8 +18,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 
 @Configuration
 @EnableWebSecurity //(debug = true)
+@RequiredArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception{
@@ -22,14 +34,21 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         http.authorizeRequests()
-                .antMatchers("/**").permitAll()
+//                .antMatchers("/v1/user/**").hasRole("GUEST")
                 .anyRequest().permitAll();
+
+        http.exceptionHandling()
+                .accessDeniedHandler(new JwtAccessDeniedHandler())
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint());
+
+        http.apply(new JwtFilterConfig(jwtTokenProvider));
+        http.apply(new ExceptionHandlerFilterConfig(exceptionHandlerFilter));
     }
 
     @Override
     public void configure(WebSecurity web) {
         web.ignoring()
-                .antMatchers("/**") // 후에 Security 설정을 완료하고 제거
+//                .antMatchers("/**") // 후에 Security 설정을 완료하고 제거
                 .antMatchers("/h2-console/**", "/exception/**")
                 .antMatchers("/swagger-resources/**")
                 .antMatchers("/swagger-ui.html")
@@ -39,4 +58,5 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/configuration/security")
                 .antMatchers("/context/**");
     }
+
 }

--- a/src/main/java/com/server/amething/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/server/amething/global/config/security/WebSecurityConfig.java
@@ -48,7 +48,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) {
         web.ignoring()
-//                .antMatchers("/**") // 후에 Security 설정을 완료하고 제거
+                .antMatchers("/**") // 후에 Security 설정을 완료하고 제거
                 .antMatchers("/h2-console/**", "/exception/**")
                 .antMatchers("/swagger-resources/**")
                 .antMatchers("/swagger-ui.html")

--- a/src/main/java/com/server/amething/global/jwt/config/CustomUserDetails.java
+++ b/src/main/java/com/server/amething/global/jwt/config/CustomUserDetails.java
@@ -18,6 +18,6 @@ public class CustomUserDetails implements UserDetailsService {
         long id = Long.parseLong(username);
 
         return userRepository.findByOauthId(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
     }
 }

--- a/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilter.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.amething.global.exception.response.ErrorResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,33 +21,40 @@ import java.io.IOException;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class ExceptionHandleFilter extends OncePerRequestFilter {
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException {
         try {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException ex) {
             log.debug("================= [ ExceptionHandlerFilter ] 에서 ExpiredJwtException 발생 ===================");
-            setErrorResponse(HttpStatus.UNAUTHORIZED, response);
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, "token의 유효기간이 만료 되었습니다.");
+        } catch (SignatureException ex) {
+            log.debug("================= [ ExceptionHandlerFilter ] 에서 SignatureException 발생 ===================");
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, "token의 secretKey가 변질 되었습니다.");
+        } catch (MalformedJwtException ex) {
+            log.debug("================= [ ExceptionHandlerFilter ] 에서 MalformedJwtException 발생 ===================");
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, "token이 위조 되었습니다.");
         } catch (JwtException | IllegalArgumentException ex) {
             log.debug("================= [ ExceptionHandlerFilter ] 에서 JwtException 발생 ===================");
-            setErrorResponse(HttpStatus.FORBIDDEN, response);
+            setErrorResponse(HttpStatus.FORBIDDEN, response, "요청에 사용된 token이 올바르지 않습니다.");
         } catch (Exception ex) {
             log.debug("================= [ ExceptionHandlerFilter ] 에서 Exception 발생 ===================");
-            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response);
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response, "알 수 없는 SERVER 에러가 발생하였습니다.");
         }
     }
 
-    public void setErrorResponse(HttpStatus httpStatus, HttpServletResponse response) throws IOException {
+    public void setErrorResponse(HttpStatus httpStatus, HttpServletResponse response, String message) throws IOException {
         response.setStatus(httpStatus.value());
         response.setContentType("application/json; charset=utf-8");
 
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .status(httpStatus.value())
                 .error(httpStatus.name())
+                .message(message)
                 .build();
         String errorResponseEntityToJson = objectMapper.writeValueAsString(errorResponse);
         response.getWriter().write(errorResponseEntityToJson.toString());

--- a/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,54 @@
+package com.server.amething.global.jwt.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.amething.global.exception.response.ErrorResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ExceptionHandleFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException ex) {
+            log.debug("================= [ ExceptionHandlerFilter ] 에서 ExpiredJwtException 발생 ===================");
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response);
+        } catch (JwtException | IllegalArgumentException ex) {
+            log.debug("================= [ ExceptionHandlerFilter ] 에서 JwtException 발생 ===================");
+            setErrorResponse(HttpStatus.FORBIDDEN, response);
+        } catch (Exception ex) {
+            log.debug("================= [ ExceptionHandlerFilter ] 에서 Exception 발생 ===================");
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response);
+        }
+    }
+
+    public void setErrorResponse(HttpStatus httpStatus, HttpServletResponse response) throws IOException {
+        response.setStatus(httpStatus.value());
+        response.setContentType("application/json; charset=utf-8");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(httpStatus.value())
+                .error(httpStatus.name())
+                .build();
+        String errorResponseEntityToJson = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(errorResponseEntityToJson.toString());
+    }
+
+}

--- a/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilterConfig.java
+++ b/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilterConfig.java
@@ -1,0 +1,2 @@
+package com.server.amething.global.jwt.exception;public class ExceptionHandlerFilterConfig {
+}

--- a/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilterConfig.java
+++ b/src/main/java/com/server/amething/global/jwt/exception/ExceptionHandlerFilterConfig.java
@@ -1,2 +1,20 @@
-package com.server.amething.global.jwt.exception;public class ExceptionHandlerFilterConfig {
+package com.server.amething.global.jwt.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class ExceptionHandlerFilterConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
+
+    @Override
+    public void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.addFilterBefore(exceptionHandlerFilter, SecurityContextPersistenceFilter.class);
+    }
 }


### PR DESCRIPTION
AccessToken이 만료되었을때 RefreshToken을 통해 AccessToken을 재발급 하는 로직을 만들었습니다.
(재발급 요청을 위해 받은 인자 RefreshToken이 user에 저장된 RefreshToken과 일치하지 않다면 예외를 던집니다.)

또한 AccessToken을 통한 권한 검증및 토큰 유효성 검사에서 각자 알맞은 예외를 던지도록 ExceptionHandler를 생성했습니다. (401, 403)
401과 403이 알맞은 상황, 그리고 제대로 뜨는지 swagger에서 통합테스트를 마쳤습니다.