### PR TITLE
테스트와 개발편의성을 위해 PostConstruct를 이용해 유저를 가입시켜놓는 util 클래스를 개발

### DIFF
--- a/src/main/java/com/server/amething/global/util/GenerateMemberUtil.java
+++ b/src/main/java/com/server/amething/global/util/GenerateMemberUtil.java
@@ -1,0 +1,50 @@
+package com.server.amething.global.util;
+
+import com.server.amething.domain.user.User;
+import com.server.amething.domain.user.enum_type.Role;
+import com.server.amething.domain.user.repository.UserRepository;
+import com.server.amething.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Collections;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenerateMemberUtil {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @PostConstruct
+    private void generateMember() {
+        String refreshToken = "Bearer " + jwtTokenProvider.createRefreshToken();
+
+        User kimtaemin = constructor("김태민", 2249049915L, refreshToken);
+        User jeongyongwoo = constructor("정용우", 2249049916L, refreshToken);
+
+        String taeminAccessToken = jwtTokenProvider.createAccessToken(kimtaemin.getUsername(), kimtaemin.getRoles());
+        String yongwooAccessToken = jwtTokenProvider.createAccessToken(jeongyongwoo.getUsername(), jeongyongwoo.getRoles());
+
+        log.info("[================== generateMember =================]");
+        log.info("김태민의 accessToken = {}", "Bearer " + taeminAccessToken);
+        log.info("정용우의 accessToken = {}", "Bearer " + yongwooAccessToken);
+        log.info("공용 refreshToken = {}", refreshToken);
+        log.info("[===================== finish ======================]");
+
+    }
+
+    private User constructor(String nickname, Long oauthId, String refreshToken) {
+        return userRepository.save(User.builder()
+                .nickname(nickname)
+                .oauthId(oauthId)
+                .bio(nickname +"의 한줄소개")
+                .profilePicture("http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg")
+                .roles(Collections.singletonList(Role.ROLE_MEMBER))
+                .refreshToken(refreshToken)
+                .build());
+    }
+}


### PR DESCRIPTION
@PostConstruct 를 이용해 WAS가 띄어질때 
자동으로 user를 가입시켜놓아 oauth를 통한 로그인을 하지 않아도 바로 테스트를 할 수 있게 자동화 하였습니다.

사용방법은 Application을 run하면

<img width="1229" alt="스크린샷 2022-06-27 15 22 17" src="https://user-images.githubusercontent.com/69895452/175874024-86469fd6-ca76-4293-9a94-7adb00831046.png">
해당 로그에 AccessToken과 RefreshToken 정보가 logging됩니다. refreshToken은 subject가 따로 존재하지 않고,
만료기간 정보만 저장되어 있기때문에 공용으로 사용되게 설정 해두었습니다.

간편하게 accessToken만 `copy & paste 개발방법론`을 이용해 편안한 개발 하시면 좋을거 같습니다~
