### PR TITLE
ngrok 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 	asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+	compile 'io.github.kilmajster:ngrok-spring-boot-starter:0.6.0'
 }
 tasks.named('test') {
 	useJUnitPlatform()


### PR DESCRIPTION
기존 ngrok을 외부에서 실행시키는게 아닌 application 로딩 시점에서 native하게 실행 시킬 수 있는 라이브러리를 채택하였습니다.

application을 run하면 서버가 정상실행 되고나서 1초 정도를 기다리시면 아래 첨부한 사진과 같이 ngrok 서버가 열리는걸 확인 하실 수 있을겁니다. 이 ngrok 서버 url을 통해 swagger, h2-console, spring-rest-docs로 작성된 api 명세서에 접근이 가능합니다.

<img width="862" alt="스크린샷 2022-08-04 17 34 36" src="https://user-images.githubusercontent.com/69895452/182802502-b05db03c-0ac1-4a72-9018-a5238ef62a7c.png">

++
application.yml의 변동이 일어났으니 제가 디스코드에 첨부한 yml로 최신화 해주세요!